### PR TITLE
Install Oracle JDK 6, 7, and 8 on vsts standard image

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The Ubuntu-based images include the following tools:
 - Basic command-line utilities (curl, ftp, etc.)
 - Essential build tools (gcc, make, etc.)
 - Python and Python 3
-- OpenJDK 7 (Ubuntu 14.04) or 8 (Ubuntu 16.04)
+- Oracle JDK 6, 7 (Default JDK on 14.04) and 8 (Default JDK on 16.04)
 - Java tools (ant, gradle, maven)
 - .NET Core SDK
 - Node.js (latest stable version)

--- a/ubuntu/derived/standard/Dockerfile.template
+++ b/ubuntu/derived/standard/Dockerfile.template
@@ -23,12 +23,26 @@ RUN echo "deb [arch=amd64] http://apt-mo.trafficmanager.net/repos/dotnet-release
     # Python
     python \
     python3 \
-    # Java and related build tools
-    openjdk-$(OPENJDK_VERSION)-jdk \
-    ant \
-    ant-optional \
     # .NET Core SDK
     dotnet-dev-1.0.1 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Oracle JDKs
+RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections \
+ && echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections \
+ && apt-add-repository -y ppa:webupd8team/java \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    oracle-java6-installer \
+    oracle-java7-installer \
+    oracle-java8-installer \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ant separately to avoid apt-get errors
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    ant \
+    ant-optional \
  && rm -rf /var/lib/apt/lists/*
 
 # Install maven separately to avoid apt-get errors
@@ -55,5 +69,9 @@ ENV ANT_HOME=/usr/share/ant \
     dotnet=/usr/bin/dotnet \
     GRADLE_HOME=/usr/share/gradle \
     grunt=/usr/local/bin/grunt \
-    JAVA_HOME=/usr/lib/jvm/java-$(OPENJDK_VERSION)-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-oracle \
+    JAVA_HOME_6_X64=/usr/lib/jvm/java-6-oracle \
+    JAVA_HOME_7_X64=/usr/lib/jvm/java-7-oracle \
+    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-oracle \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 \
     M2_HOME=/usr/share/maven \

--- a/ubuntu/derived/standard/README.md
+++ b/ubuntu/derived/standard/README.md
@@ -4,7 +4,7 @@ The Ubuntu-based standard images include the following tools:
 - Basic command-line utilities (curl, ftp, etc.)
 - Essential build tools (gcc, make, etc.)
 - Python and Python 3
-- OpenJDK 7 (Ubuntu 14.04) or 8 (Ubuntu 16.04)
+- Oracle JDK 6, 7 (Default JDK on 14.04) and 8 (Default JDK on 16.04)
 - Java tools (ant, gradle, maven)
 - .NET Core SDK
 - Node.js (latest stable version)

--- a/update.sh
+++ b/update.sh
@@ -46,14 +46,14 @@ ubuntu() {
         unix2dos -q $DOCKER_DIR/Dockerfile
       fi
 
-      while read TARGET_UBUNTU_VERSION UBUNTU_RELEASE OPENJDK_VERSION; do
+      while read TARGET_UBUNTU_VERSION UBUNTU_RELEASE DEFAULT_JDK_VERSION; do
         if [ "$UBUNTU_VERSION" == "$TARGET_UBUNTU_VERSION" ]; then
           STANDARD_DIR=$DOCKER_DIR/standard
           mkdir -p $STANDARD_DIR
           sed \
             -e s/'$(VSTS_AGENT_TAG)'/$VSTS_AGENT_TAG-docker-$DOCKER_VERSION/g \
             -e s/'$(UBUNTU_RELEASE)'/$UBUNTU_RELEASE/g \
-            -e s/'$(OPENJDK_VERSION)'/$OPENJDK_VERSION/g \
+            -e s/'$(DEFAULT_JDK_VERSION)'/$DEFAULT_JDK_VERSION/g \
             derived/standard/Dockerfile.template > $STANDARD_DIR/Dockerfile
           if [ -n "$(which unix2dos)" ]; then
             unix2dos -q $STANDARD_DIR/Dockerfile


### PR DESCRIPTION
1. Install Oracle JDK 6, 7, and 8.
2. Setup environment variables used by VSTS Java (Ant/Maven/Gradle) tasks.