### PR TITLE
enable volumes for _work dir

### DIFF
--- a/ubuntu/14.04/start.sh
+++ b/ubuntu/14.04/start.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
+shopt -s extglob
 
 if [ -e /vsts/agent -a ! -e /vsts/agent/.agent ]; then
-  rm -rf /vsts/agent
+  rm -rf /vsts/agent/!(_work)
 fi
 
-if [ -e /vsts/agent ]; then
+if [ -e /vsts/agent -a -e /vsts/agent/bin/Agent.Listener ]; then
   export VSO_AGENT_IGNORE=_,MAIL,OLDPWD,PATH,PWD,UBUNTU_VERSION,VSO_AGENT_IGNORE
   if [ -n "$VSTS_AGENT_IGNORE" ]; then
     export VSO_AGENT_IGNORE=$VSO_AGENT_IGNORE,VSTS_AGENT_IGNORE,$VSTS_AGENT_IGNORE

--- a/ubuntu/16.04/start.sh
+++ b/ubuntu/16.04/start.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -e
+shopt -s extglob
 
 if [ -e /vsts/agent -a ! -e /vsts/agent/.agent ]; then
-  rm -rf /vsts/agent
+  rm -rf /vsts/agent/!(_work)
 fi
 
-if [ -e /vsts/agent ]; then
+if [ -e /vsts/agent -a -e /vsts/agent/bin/Agent.Listener ]; then
   export VSO_AGENT_IGNORE=_,MAIL,OLDPWD,PATH,PWD,UBUNTU_VERSION,VSO_AGENT_IGNORE
   if [ -n "$VSTS_AGENT_IGNORE" ]; then
     export VSO_AGENT_IGNORE=$VSO_AGENT_IGNORE,VSTS_AGENT_IGNORE,$VSTS_AGENT_IGNORE
@@ -35,7 +36,6 @@ if [ -n "$VSTS_WORK" ]; then
   mkdir -p "$VSTS_WORK"
 fi
 
-mkdir /vsts/agent
 cd /vsts/agent
 
 cleanup() {

--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
+shopt -s extglob
 
 if [ -e /vsts/agent -a ! -e /vsts/agent/.agent ]; then
-  rm -rf /vsts/agent
+  rm -rf /vsts/agent/!(_work)
 fi
 
-if [ -e /vsts/agent ]; then
-  export VSO_AGENT_IGNORE=_,MAIL,OLDPWD,PATH,PWD,UBUNTU_VERSION,VSO_AGENT_IGNORE
+if [ -e /vsts/agent -a -e /vsts/agent/bin/Agent.Listener ]; then
+ export VSO_AGENT_IGNORE=_,MAIL,OLDPWD,PATH,PWD,UBUNTU_VERSION,VSO_AGENT_IGNORE
   if [ -n "$VSTS_AGENT_IGNORE" ]; then
     export VSO_AGENT_IGNORE=$VSO_AGENT_IGNORE,VSTS_AGENT_IGNORE,$VSTS_AGENT_IGNORE
   fi


### PR DESCRIPTION
Possible fix for #22.  Opening PR for discussion.

Don't delete /vsts/agent/_work dir so can mapped and containers can be used to build source with in the vsts agent container. 
