### PR TITLE
Remove existing agent config.

### DIFF
--- a/ubuntu/14.04/tfs/2017/start.sh
+++ b/ubuntu/14.04/tfs/2017/start.sh
@@ -32,6 +32,11 @@ cleanup() {
     --token "$VSTS_TOKEN"
 }
 
+if [ -e /vsts/agent/.agent ]; then
+  echo "Agent config still exists, removing it..."
+  cleanup
+fi
+
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 

--- a/ubuntu/16.04/tfs/2017/start.sh
+++ b/ubuntu/16.04/tfs/2017/start.sh
@@ -32,6 +32,11 @@ cleanup() {
     --token "$VSTS_TOKEN"
 }
 
+if [ -e /vsts/agent/.agent ]; then
+  echo "Agent config still exists, removing it..."
+  cleanup
+fi
+
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 

--- a/ubuntu/versioned/start.sh
+++ b/ubuntu/versioned/start.sh
@@ -32,6 +32,11 @@ cleanup() {
     --token "$VSTS_TOKEN"
 }
 
+if [ -e /vsts/agent/.agent ]; then
+  echo "Agent config still exists, removing it..."
+  cleanup
+fi
+
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 


### PR DESCRIPTION
The config may not get always removed cleanly because sometimes the cleanup-trap doesn't get called, e.g. when the agent.Listener segfaults.

Therefore we remove an existing agent config on startup of the container.

fixes #29 