### PR TITLE
Add additional info for error message on determing matching vsts agent

### DIFF
--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -54,7 +54,7 @@ export VSTS_AGENT_URL=$(curl -LsS \
   "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=ubuntu.$UBUNTU_VERSION-x64" \
   | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
-  echo 1>&2 error: could not determine a matching VSTS agent
+  echo 1>&2 error: could not determine a matching VSTS agent. Possible issue could be incorrect VSTS_TOKEN or VSTS_ACCOUNT environment variables. 
   exit 1
 fi
 


### PR DESCRIPTION
The error message "could not determine a matching VSTS agent" does not say everything about possible errors which could happen during authentication to vsts.  Possible issues could be a wrong PAT (VSTS_TOKEN) or VSTS_ACCOUNT for which the error message is misleading.