### PR TITLE
Added support for docker secrets for the VSTS_TOKEN env

### DIFF
--- a/windows/servercore/10.0.14393/Start.ps1
+++ b/windows/servercore/10.0.14393/Start.ps1
@@ -9,7 +9,7 @@ if ($env:VSTS_TOKEN -eq $null) {
     Write-Error "Missing VSTS_TOKEN environment variable"
     exit 1
 } else {
-    if (Test-Path -Path $env:VSTS_TOKEN -ItemType Leaf) {
+    if (Test-Path -Path $env:VSTS_TOKEN -PathType Leaf) {
         $env:VSTS_TOKEN = Get-Content -Path $env:VSTS_TOKEN -ErrorAction Stop | Where-Object {$_} | Select-Object -First 1
         
         if ([string]::IsNullOrEmpty($env:VSTS_TOKEN)) {

--- a/windows/servercore/10.0.14393/Start.ps1
+++ b/windows/servercore/10.0.14393/Start.ps1
@@ -11,6 +11,11 @@ if ($env:VSTS_TOKEN -eq $null) {
 } else {
     if (Test-Path -Path $env:VSTS_TOKEN -ItemType Leaf) {
         $env:VSTS_TOKEN = Get-Content -Path $env:VSTS_TOKEN -ErrorAction Stop | Where-Object {$_} | Select-Object -First 1
+        
+        if ([string]::IsNullOrEmpty($env:VSTS_TOKEN)) {
+            Write-Error "Missing VSTS_TOKEN file content"
+            exit 1
+        }
     }
 }
 

--- a/windows/servercore/10.0.14393/Start.ps1
+++ b/windows/servercore/10.0.14393/Start.ps1
@@ -8,6 +8,10 @@ If ($env:VSTS_ACCOUNT -eq $null) {
 if ($env:VSTS_TOKEN -eq $null) {
     Write-Error "Missing VSTS_TOKEN environment variable"
     exit 1
+} else {
+    if (Test-Path -Path $env:VSTS_TOKEN -ItemType Leaf) {
+        $env:VSTS_TOKEN = Get-Content -Path $env:VSTS_TOKEN -ErrorAction Stop | Where-Object {$_} | Select-Object -First 1
+    }
 }
 
 if ($env:VSTS_AGENT -ne $null) {

--- a/windows/servercore/10.0.14393/standard/VS2015/Dockerfile
+++ b/windows/servercore/10.0.14393/standard/VS2015/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/vsts-agent:windows-10.0.14393
+FROM microsoft/vsts-agent:windows-servercore-10.0.14393
 
 
 

--- a/windows/servercore/10.0.14393/standard/VS2017/Dockerfile
+++ b/windows/servercore/10.0.14393/standard/VS2017/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/vsts-agent:windows-10.0.14393
+FROM microsoft/vsts-agent:windows-servercore-10.0.14393
 
 ENV chocolateyUseWindowsCompression=false
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"


### PR DESCRIPTION
The primary purpose is to provide the PAT as a secret to the instance, this way no hard coded PAT in docker-compose or other initialization scripts. Secondly, based on using the directory hierarchy for the tag of the image, the VS2015 and VS2017 dockerfiles are referencing the wrong generated image tag; it is missing the "servercore" folder.