### PR TITLE
Go updates. Environment variables relocated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,13 +135,13 @@ These derived images include a set of standard capabilities that enable many of 
 - Essential build tools (gcc, make, etc.)
 - Azure CLI 2.0.25
 - CMake 3.10.2
-- OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (9-internal)
-- Java Tools (Ant 1.9.6, Gradle 2.10, Maven 3.3.9)
-- Go 1.9.3 and 1.8.6
+- OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (9.0.4)
+- Java tools (Ant 1.9.6, Gradle 2.10, Maven 3.3.9)
+- Go 1.8.6 and 1.9.3
 - .NET Core SDK 2.0.0
 - Node.js 9.4.0
 - Powershell Core v6.0.0
-- Python 2.7.12 and Python 3.5.2
+- Python 2.7.12 and 3.5.2
 - Subversion 1.9.3
 
 ### `docker` images

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ These derived images include a set of standard capabilities that enable many of 
 - CMake 3.10.2
 - OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (9-internal)
 - Java Tools (Ant 1.9.6, Gradle 2.10, Maven 3.3.9)
-- Go 1.9.2
+- Go 1.9.3 and 1.8.6
 - .NET Core SDK 2.0.0
 - Node.js 9.4.0
 - Powershell Core v6.0.0

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ These derived images include a set of standard capabilities that enable many of 
 - Essential build tools (gcc, make, etc.)
 - Azure CLI 2.0.25
 - CMake 3.10.2
-- OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (9.0.4)
+- OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (1.9~b115-1ubuntu1)
 - Java tools (Ant 1.9.6, Gradle 2.10, Maven 3.3.9)
 - Go 1.8.6 and 1.9.3
 - .NET Core SDK 2.0.0

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -51,10 +51,10 @@ RUN apt-get update \
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-8-jdk \
  && rm -rf /var/lib/apt/lists/*
-RUN apt-get update \
- && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-7-jdk \
- && rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --set java /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
+    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -70,18 +70,23 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \
  && rm -rf /var/lib/apt/lists/*
+ENV ANT_HOME=/usr/share/ant \
+    GRADLE_HOME=/usr/share/gradle \
+    M2_HOME=/usr/share/maven \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
-# Install Go 1.8.6
+# Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.8.6 \
  && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.8.6.linux-amd64.tar.gz
-
-# Install Go 1.9.3
 RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.3 \
  && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.9.3.linux-amd64.tar.gz
+ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
+    GOROOT=/usr/local/go1.9.3
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -92,12 +97,15 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /et
     dotnet-sdk-2.1.4 \
  && rm -rf /var/lib/apt/lists/* \
  && dotnet help
+ENV dotnet=/usr/bin/dotnet
 
 # Install stable Node.js and related build tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n stable \
  && npm install -g bower grunt gulp n \
  && rm -rf ~/n
+ENV bower=/usr/local/bin/bower \
+    grunt=/usr/local/bin/grunt
 
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -119,22 +127,3 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     subversion \
  && rm -rf /var/lib/apt/lists/*
-
-# Configure environment variables
-ENV ANT_HOME=/usr/share/ant \
-    bower=/usr/local/bin/bower \
-    dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.3 \
-    GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GRADLE_HOME=/usr/share/gradle \
-    grunt=/usr/local/bin/grunt \
-    JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64 \
-    JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
-    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 \
-    M2_HOME=/usr/share/maven
-
-# Update path environment variable
-ENV PATH $PATH:$GOROOT/bin

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -92,7 +92,7 @@ ENV PATH $PATH:$GOROOT/bin
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
- && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-tusty-prod tusty main" > /etc/apt/sources.list.d/dotnetdev.list \
+ && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -48,10 +48,15 @@ RUN apt-get update \
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-8-jdk \
  && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-8-jdk \
+ && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -69,8 +74,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV ANT_HOME=/usr/share/ant \
     GRADLE_HOME=/usr/share/gradle \
-    M2_HOME=/usr/share/maven \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+    M2_HOME=/usr/share/maven
 
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
@@ -84,10 +88,11 @@ RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linu
 ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
     GOROOT_1_9_X64=/usr/local/go1.9.3 \
     GOROOT=/usr/local/go1.9.3
+ENV PATH $PATH:$GOROOT/bin
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
- && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list \
+ && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-tusty-prod tusty main" > /etc/apt/sources.list.d/dotnetdev.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
     apt-transport-https \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -1,5 +1,8 @@
 FROM microsoft/vsts-agent:ubuntu-14.04
 
+# Make 'apt-get install -y' fully non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -68,11 +71,17 @@ RUN apt-get update \
     maven \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-RUN curl -sL https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz -o go1.9.2.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.2 \
- && tar -C /usr/local/go1.9.2 -xzf go1.9.2.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.2.linux-amd64.tar.gz
+# Install Go 1.8.6
+RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.8.6 \
+ && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.8.6.linux-amd64.tar.gz
+
+# Install Go 1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.3 \
+ && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.3.linux-amd64.tar.gz
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -115,7 +124,9 @@ RUN apt-get update \
 ENV ANT_HOME=/usr/share/ant \
     bower=/usr/local/bin/bower \
     dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.2 \
+    GOROOT=/usr/local/go1.9.3 \
+    GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
     GRADLE_HOME=/usr/share/gradle \
     grunt=/usr/local/bin/grunt \
     JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64 \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -1,8 +1,5 @@
 FROM microsoft/vsts-agent:ubuntu-14.04
 
-# Make 'apt-get install -y' fully non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -55,7 +55,8 @@ RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/jav
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -73,10 +74,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV ANT_HOME=/usr/share/ant \
     GRADLE_HOME=/usr/share/gradle \
-    M2_HOME=/usr/share/maven \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+    M2_HOME=/usr/share/maven
 
- # Install Go
+# Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.8.6 \
  && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -55,6 +55,10 @@ RUN apt-get update \
  && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-9-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
+    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -70,18 +74,24 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \
  && rm -rf /var/lib/apt/lists/*
+ENV ANT_HOME=/usr/share/ant \
+    GRADLE_HOME=/usr/share/gradle \
+    M2_HOME=/usr/share/maven \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
- # Install Go 1.8.6
+ # Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.8.6 \
  && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.8.6.linux-amd64.tar.gz
-
-# Install Go 1.9.3
 RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.3 \
  && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.9.3.linux-amd64.tar.gz
+ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
+    GOROOT=/usr/local/go1.9.3
+ENV PATH $PATH:$GOROOT/bin
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -92,12 +102,15 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /et
     dotnet-sdk-2.1.4 \
  && rm -rf /var/lib/apt/lists/* \
  && dotnet help
+ENV dotnet=/usr/bin/dotnet
 
 # Install stable Node.js and related build tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n stable \
  && npm install -g bower grunt gulp n \
  && rm -rf ~/n
+ENV bower=/usr/local/bin/bower \
+    grunt=/usr/local/bin/grunt
 
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -119,22 +132,3 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     subversion \
  && rm -rf /var/lib/apt/lists/*
-
-# Configure environment variables
-ENV ANT_HOME=/usr/share/ant \
-    bower=/usr/local/bin/bower \
-    dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.3 \
-    GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GRADLE_HOME=/usr/share/gradle \
-    grunt=/usr/local/bin/grunt \
-    JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
-    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 \
-    M2_HOME=/usr/share/maven
-
-# Update path environment variable
-ENV PATH $PATH:$GOROOT/bin

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -1,5 +1,8 @@
 FROM microsoft/vsts-agent:ubuntu-16.04
 
+# Make 'apt-get install -y' fully non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -68,11 +71,17 @@ RUN apt-get update \
     maven \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-RUN curl -sL https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz -o go1.9.2.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.2 \
- && tar -C /usr/local/go1.9.2 -xzf go1.9.2.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.2.linux-amd64.tar.gz
+ # Install Go 1.8.6
+RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.8.6 \
+ && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.8.6.linux-amd64.tar.gz
+
+# Install Go 1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.3 \
+ && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.3.linux-amd64.tar.gz
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -115,7 +124,9 @@ RUN apt-get update \
 ENV ANT_HOME=/usr/share/ant \
     bower=/usr/local/bin/bower \
     dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.2 \
+    GOROOT=/usr/local/go1.9.3 \
+    GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
     GRADLE_HOME=/usr/share/gradle \
     grunt=/usr/local/bin/grunt \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -1,8 +1,5 @@
 FROM microsoft/vsts-agent:ubuntu-16.04
 
-# Make 'apt-get install -y' fully non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -1,8 +1,5 @@
 FROM microsoft/vsts-agent:$(VSTS_AGENT_TAG)
 
-# Make 'apt-get install -y' fully non-interactive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -55,7 +55,8 @@ RUN update-alternatives --set java /usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-open
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_HOME_$(ADDITIONAL_JDK_VERSION)_X64=/usr/lib/jvm/java-$(ADDITIONAL_JDK_VERSION)-openjdk-amd64 \
-    JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64
+    JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64 \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -73,8 +74,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV ANT_HOME=/usr/share/ant \
     GRADLE_HOME=/usr/share/gradle \
-    M2_HOME=/usr/share/maven \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+    M2_HOME=/usr/share/maven
 
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -1,5 +1,8 @@
 FROM microsoft/vsts-agent:$(VSTS_AGENT_TAG)
 
+# Make 'apt-get install -y' fully non-interactive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -68,11 +71,17 @@ RUN apt-get update \
     maven \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Go
-RUN curl -sL https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz -o go1.9.2.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.2 \
- && tar -C /usr/local/go1.9.2 -xzf go1.9.2.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.2.linux-amd64.tar.gz
+ # Install Go 1.8.6
+RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.8.6 \
+ && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.8.6.linux-amd64.tar.gz
+
+# Install Go 1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.3 \
+ && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.3.linux-amd64.tar.gz
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -115,7 +124,9 @@ RUN apt-get update \
 ENV ANT_HOME=/usr/share/ant \
     bower=/usr/local/bin/bower \
     dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.2 \
+    GOROOT=/usr/local/go1.9.3 \
+    GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
     GRADLE_HOME=/usr/share/gradle \
     grunt=/usr/local/bin/grunt \
     JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64 \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -55,6 +55,10 @@ RUN apt-get update \
  && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-$(ADDITIONAL_JDK_VERSION)-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64/jre/bin/java
+ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
+    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME_$(ADDITIONAL_JDK_VERSION)_X64=/usr/lib/jvm/java-$(ADDITIONAL_JDK_VERSION)-openjdk-amd64 \
+    JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64
 
 # Install Java Tools (Ant, Gradle, Maven)
 RUN apt-get update \
@@ -70,18 +74,24 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \
  && rm -rf /var/lib/apt/lists/*
+ENV ANT_HOME=/usr/share/ant \
+    GRADLE_HOME=/usr/share/gradle \
+    M2_HOME=/usr/share/maven \
+    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 
- # Install Go 1.8.6
+# Install Go
 RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.8.6 \
  && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.8.6.linux-amd64.tar.gz
-
-# Install Go 1.9.3
 RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.3 \
  && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
  && rm go1.9.3.linux-amd64.tar.gz
+ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
+    GOROOT_1_9_X64=/usr/local/go1.9.3 \
+    GOROOT=/usr/local/go1.9.3
+ENV PATH $PATH:$GOROOT/bin
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg \
@@ -92,12 +102,15 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /et
     dotnet-sdk-2.1.4 \
  && rm -rf /var/lib/apt/lists/* \
  && dotnet help
+ENV dotnet=/usr/bin/dotnet
 
 # Install stable Node.js and related build tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n stable \
  && npm install -g bower grunt gulp n \
  && rm -rf ~/n
+ENV bower=/usr/local/bin/bower \
+    grunt=/usr/local/bin/grunt
 
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
@@ -119,22 +132,3 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     subversion \
  && rm -rf /var/lib/apt/lists/*
-
-# Configure environment variables
-ENV ANT_HOME=/usr/share/ant \
-    bower=/usr/local/bin/bower \
-    dotnet=/usr/bin/dotnet \
-    GOROOT=/usr/local/go1.9.3 \
-    GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GRADLE_HOME=/usr/share/gradle \
-    grunt=/usr/local/bin/grunt \
-    JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64 \
-    JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
-    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_$(ADDITIONAL_JDK_VERSION)_X64=/usr/lib/jvm/java-$(ADDITIONAL_JDK_VERSION)-openjdk-amd64 \
-    JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8 \
-    M2_HOME=/usr/share/maven
-
-# Update path environment variable
-ENV PATH $PATH:$GOROOT/bin

--- a/ubuntu/standard/versions
+++ b/ubuntu/standard/versions
@@ -1,2 +1,2 @@
-14.04 trusty 7
+14.04 trusty 8
 16.04 xenial 8 9


### PR DESCRIPTION
This PR changes the install of Go 1.9.2 to the new 1.9.3.  It also installs the previous dot release: 1.8.6.  Including the latest 2 dot releases of Go is what other hosted CI providers do.

Also, the environment variables at the bottom of the dockerfiles were moved to be just under the installations of the tools to which they belong.

I tested this PR by building the 14.04 and 16.04 dockerfiles successfully.