### PR TITLE
Update error handling for invalid PAT token

### DIFF
--- a/ubuntu/14.04/start.sh
+++ b/ubuntu/14.04/start.sh
@@ -63,7 +63,7 @@ VSTS_AGENT_URL=$(curl -LsS \
 set -e
 
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
-  echo 1>&2 error: could not determine a matching VSTS agent
+  echo 1>&2 error: could not determine a matching VSTS agent - check that account \'$VSTS_ACCOUNT\' is correct and the token is valid for that account
   exit 1
 fi
 

--- a/ubuntu/14.04/start.sh
+++ b/ubuntu/14.04/start.sh
@@ -54,11 +54,20 @@ trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
 echo Determining matching VSTS agent...
-VSTS_AGENT_URL=$(curl -LsS \
+VSTS_AGENT_RESPONSE=$(curl -LsS \
   -u user:$(cat "$VSTS_TOKEN_FILE") \
   -H 'Accept:application/json;api-version=3.0-preview' \
-  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64" \
-  | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+else
+  echo 1>&2 error: did not recieve a valid response from server. \
+    Check that your VSTS_TOKEN is valid and \'"$VSTS_ACCOUNT"\' is the correct VSTS_ACCOUNT
+  exit 1
+fi
+
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
   echo 1>&2 error: could not determine a matching VSTS agent
   exit 1

--- a/ubuntu/16.04/start.sh
+++ b/ubuntu/16.04/start.sh
@@ -63,7 +63,7 @@ VSTS_AGENT_URL=$(curl -LsS \
 set -e
 
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
-  echo 1>&2 error: could not determine a matching VSTS agent
+  echo 1>&2 error: could not determine a matching VSTS agent - check that account \'$VSTS_ACCOUNT\' is correct and the token is valid for that account
   exit 1
 fi
 

--- a/ubuntu/16.04/start.sh
+++ b/ubuntu/16.04/start.sh
@@ -54,11 +54,20 @@ trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
 echo Determining matching VSTS agent...
-VSTS_AGENT_URL=$(curl -LsS \
+VSTS_AGENT_RESPONSE=$(curl -LsS \
   -u user:$(cat "$VSTS_TOKEN_FILE") \
   -H 'Accept:application/json;api-version=3.0-preview' \
-  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64" \
-  | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+else
+  echo 1>&2 error: did not recieve a valid response from server. \
+    Check that your VSTS_TOKEN is valid and \'"$VSTS_ACCOUNT"\' is the correct VSTS_ACCOUNT
+  exit 1
+fi
+
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
   echo 1>&2 error: could not determine a matching VSTS agent
   exit 1

--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -63,7 +63,7 @@ VSTS_AGENT_URL=$(curl -LsS \
 set -e
 
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
-  echo 1>&2 error: could not determine a matching VSTS agent
+  echo 1>&2 error: could not determine a matching VSTS agent - check that account \'$VSTS_ACCOUNT\' is correct and the token is valid for that account
   exit 1
 fi
 

--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -54,11 +54,20 @@ trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
 echo Determining matching VSTS agent...
-VSTS_AGENT_URL=$(curl -LsS \
+VSTS_AGENT_RESPONSE=$(curl -LsS \
   -u user:$(cat "$VSTS_TOKEN_FILE") \
   -H 'Accept:application/json;api-version=3.0-preview' \
-  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64" \
-  | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+  "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+  VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+else
+  echo 1>&2 error: did not recieve a valid response from server. \
+    Check that your VSTS_TOKEN is valid and \'"$VSTS_ACCOUNT"\' is the correct VSTS_ACCOUNT
+  exit 1
+fi
+
 if [ -z "$VSTS_AGENT_URL" -o "$VSTS_AGENT_URL" == "null" ]; then
   echo 1>&2 error: could not determine a matching VSTS agent
   exit 1


### PR DESCRIPTION
Fixes https://github.com/Microsoft/vsts-agent-docker/issues/70

Invalidates https://github.com/Microsoft/vsts-agent-docker/pull/38

When startup script attempts to download agent with an invalid PAT token or an incorrect account name, server returns a redirect to a sign in page or a 404, respectively, as html. jq fails to parse download link from html and errors out

Precise error can be determined by parsing http status from response but this seems fragile. Current fix just validates if response is valid JSON, and prints a more helpful error if it is not