### PR TITLE
Fix broken error handling 

### DIFF
--- a/ubuntu/14.04/start.sh
+++ b/ubuntu/14.04/start.sh
@@ -59,7 +59,7 @@ VSTS_AGENT_RESPONSE=$(curl -LsS \
   -H 'Accept:application/json;api-version=3.0-preview' \
   "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
 
-if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+if echo "$VSTS_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
   VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
     | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
 fi

--- a/ubuntu/16.04/start.sh
+++ b/ubuntu/16.04/start.sh
@@ -59,7 +59,7 @@ VSTS_AGENT_RESPONSE=$(curl -LsS \
   -H 'Accept:application/json;api-version=3.0-preview' \
   "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
 
-if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+if echo "$VSTS_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
   VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
     | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
 fi

--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -59,7 +59,7 @@ VSTS_AGENT_RESPONSE=$(curl -LsS \
   -H 'Accept:application/json;api-version=3.0-preview' \
   "https://$VSTS_ACCOUNT.visualstudio.com/_apis/distributedtask/packages/agent?platform=linux-x64")
 
-if echo "$VSTS_AGENT_RESPONSE" | jq -e . >/dev/null 2>&1; then
+if echo "$VSTS_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
   VSTS_AGENT_URL=$(echo "$VSTS_AGENT_RESPONSE" \
     | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
 fi


### PR DESCRIPTION
@stepro 
As I wrote in https://github.com/Microsoft/vsts-agent-docker/pull/71, the last changes fixed the error case, but I did not properly test the success case, and those changes broke when receiving a valid json response from the server. 

Coincidentally, the original changes I proposed work in both cases, although at the time I did not foresee that. Having the extra step of validating the response prevents curl from leaking error (23) without the need for silencing all curl errors, and it hides generic jq parse errors, falling through to our general error message that should now be more helpful than before. 

Removed -e flag from jq, it fails properly on invalid input without it, and it wasnt available in the version of jq (1.3) that gets picked up on the ubuntu 14 image (ubuntu 16 picks up jq 1.5)