### PR TITLE
Correct documentation regarding TFS_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ When using an image that targets a specific TFS version, the connection informat
 - `TFS_URL`: the full URL of the Team Foundation Server
 - `VSTS_TOKEN`: a personal access token (PAT) for the Team Foundation Server account that has been given at least the **Agent Pools (read, manage)** scope.
 
-If `TFS_HOST` is provided, the TFS URL is set to `http://$TFS_HOST:8080/tfs`. If `TFS_URL` is provided, any `TFS_HOST` environment variable is ignored.
+If `TFS_HOST` is provided, the TFS URL is set to `https://$TFS_HOST/tfs`. If `TFS_URL` is provided, any `TFS_HOST` environment variable is ignored.
 
 To run a VSTS agent image for TFS 2017 that identifies the server at `http://mytfs:8080/tfs`:
 


### PR DESCRIPTION
It seems that running `docker run -e TFS_HOST=mytfs ... microsoft/vsts-agent:ubuntu-16.04-tfs-2017-u1-docker-17.12.0-ce` sets the url to `https://$TFS_HOST/tfs` instead of `http://TFS_HOST:8080/tfs`

It took me a while to understand why my agent would not run, because of this. I expected the communication to be done in http according to this and not https. The real reason why my agent didn't work, is that the https certificate is self-signed and the agent won't accept it.

Here's an excerpt from `_diag/Agent.log` with `TFS_HOST=mytfs`:

```
[2018-02-13 11:05:56Z INFO CommandLineParser] Adding option 'url': 'https://mytfs/tfs'
```

EDIT: here's the source: https://github.com/Microsoft/vsts-agent-docker/blob/3e9980974a1343e6acc5a1a0095bc7dde05c2dbc/ubuntu/tfs/start.sh#L10