### PR TITLE
Update installed versions of Go to 1.9.4 and 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ These derived images include a set of standard capabilities that enable many of 
 - Essential build tools (gcc, make, etc.)
 - Azure CLI 2.0.27
 - CMake 3.10.2
-- Go 1.8.6 and 1.9.3
+- Go 1.9.4 and 1.10
 - OpenJDK 7 (1.7.0_95), 8 (1.8.0_151), and 9 (1.9~b115-1ubuntu1)
 - Java tools (Ant 1.9.6, Gradle 2.10, Maven 3.3.9)
 - MySQL Client 14.14

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -41,17 +41,17 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && rm cmake.sh
 
 # Install Go
-RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.8.6 \
- && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.8.6.linux-amd64.tar.gz
-RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.3 \
- && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.3.linux-amd64.tar.gz
-ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GOROOT=/usr/local/go1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.4 \
+ && tar -C /usr/local/go1.9.4 -xzf go1.9.4.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.4.linux-amd64.tar.gz
+RUN curl -sL https://dl.google.com/go/go1.10.linux-amd64.tar.gz -o go1.10.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.10 \
+ && tar -C /usr/local/go1.10 -xzf go1.10.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.10.linux-amd64.tar.gz
+ENV GOROOT_1_9_X64=/usr/local/go1.9.4 \
+    GOROOT_1_10_X64=/usr/local/go1.10 \
+    GOROOT=/usr/local/go1.10
 ENV PATH $PATH:$GOROOT/bin
 
 # Install OpenJDKs

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -41,17 +41,17 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && rm cmake.sh
 
 # Install Go
-RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.8.6 \
- && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.8.6.linux-amd64.tar.gz
-RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.3 \
- && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.3.linux-amd64.tar.gz
-ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GOROOT=/usr/local/go1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.4 \
+ && tar -C /usr/local/go1.9.4 -xzf go1.9.4.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.4.linux-amd64.tar.gz
+RUN curl -sL https://dl.google.com/go/go1.10.linux-amd64.tar.gz -o go1.10.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.10 \
+ && tar -C /usr/local/go1.10 -xzf go1.10.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.10.linux-amd64.tar.gz
+ENV GOROOT_1_9_X64=/usr/local/go1.9.4 \
+    GOROOT_1_10_X64=/usr/local/go1.10 \
+    GOROOT=/usr/local/go1.10
 ENV PATH $PATH:$GOROOT/bin
 
 # Install OpenJDKs

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -41,17 +41,17 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && rm cmake.sh
 
 # Install Go
-RUN curl -sL https://dl.google.com/go/go1.8.6.linux-amd64.tar.gz -o go1.8.6.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.8.6 \
- && tar -C /usr/local/go1.8.6 -xzf go1.8.6.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.8.6.linux-amd64.tar.gz
-RUN curl -sL https://dl.google.com/go/go1.9.3.linux-amd64.tar.gz -o go1.9.3.linux-amd64.tar.gz \
- && mkdir -p /usr/local/go1.9.3 \
- && tar -C /usr/local/go1.9.3 -xzf go1.9.3.linux-amd64.tar.gz --strip-components=1 go \
- && rm go1.9.3.linux-amd64.tar.gz
-ENV GOROOT_1_8_X64=/usr/local/go1.8.6 \
-    GOROOT_1_9_X64=/usr/local/go1.9.3 \
-    GOROOT=/usr/local/go1.9.3
+RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.9.4 \
+ && tar -C /usr/local/go1.9.4 -xzf go1.9.4.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.9.4.linux-amd64.tar.gz
+RUN curl -sL https://dl.google.com/go/go1.10.linux-amd64.tar.gz -o go1.10.linux-amd64.tar.gz \
+ && mkdir -p /usr/local/go1.10 \
+ && tar -C /usr/local/go1.10 -xzf go1.10.linux-amd64.tar.gz --strip-components=1 go \
+ && rm go1.10.linux-amd64.tar.gz
+ENV GOROOT_1_9_X64=/usr/local/go1.9.4 \
+    GOROOT_1_10_X64=/usr/local/go1.10 \
+    GOROOT=/usr/local/go1.10
 ENV PATH $PATH:$GOROOT/bin
 
 # Install OpenJDKs


### PR DESCRIPTION
Tested by running `update.sh`, building `ubuntu/14.04/standard/Dockerfile` and `ubuntu/16.04/standard/Dockerfile`, and running the installed Go executables.