### PR TITLE
Update to install latest (4.6) Gradle version

### DIFF
--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -78,10 +78,10 @@ RUN apt-get update \
     ant \
     ant-optional \
  && rm -rf /var/lib/apt/lists/*
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    gradle \
- && rm -rf /var/lib/apt/lists/*
+RUN curl -sL https://services.gradle.org/distributions/gradle-4.6-bin.zip -o gradle-4.6.zip \
+ && unzip -d /usr/share gradle-4.6.zip \
+ && ln -s /usr/share/gradle-4.6/bin/gradle /usr/bin/gradle \
+ && rm gradle-4.6.zip
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -78,10 +78,10 @@ RUN apt-get update \
     ant \
     ant-optional \
  && rm -rf /var/lib/apt/lists/*
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    gradle \
- && rm -rf /var/lib/apt/lists/*
+RUN curl -sL https://services.gradle.org/distributions/gradle-4.6-bin.zip -o gradle-4.6.zip \
+ && unzip -d /usr/share gradle-4.6.zip \
+ && ln -s /usr/share/gradle-4.6/bin/gradle /usr/bin/gradle \
+ && rm gradle-4.6.zip
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -78,10 +78,10 @@ RUN apt-get update \
     ant \
     ant-optional \
  && rm -rf /var/lib/apt/lists/*
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    gradle \
- && rm -rf /var/lib/apt/lists/*
+RUN curl -sL https://services.gradle.org/distributions/gradle-4.6-bin.zip -o gradle-4.6.zip \
+ && unzip -d /usr/share gradle-4.6.zip \
+ && ln -s /usr/share/gradle-4.6/bin/gradle /usr/bin/gradle \
+ && rm gradle-4.6.zip
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     maven \


### PR DESCRIPTION
Updating to install the latest Gradle version (4.6). Ubuntu currently doesn't have newer versions of Gradle available in their repo, so we have to download directly from the Gradle site.

Verified on Ubuntu 16.04 and 14.04.