### PR TITLE
Change VSTS_WORK value

### DIFF
--- a/ubuntu/16.04/start.sh
+++ b/ubuntu/16.04/start.sh
@@ -86,7 +86,7 @@ source ./env.sh
   --auth PAT \
   --token $(cat "$VSTS_TOKEN_FILE") \
   --pool "${VSTS_POOL:-Default}" \
-  --work "${VSTS_WORK:-_work}" \
+  --work "${VSTS_WORK:-work_}" \
   --replace & wait $!
 
 web-server &


### PR DESCRIPTION
The command, docker volume create, cannot mount a path with a directory that starts with an underscore.