### PR TITLE
Fail on invalid VSTS_WORK environment variables

### DIFF
--- a/ubuntu/start.sh
+++ b/ubuntu/start.sh
@@ -35,6 +35,10 @@ fi
 if [ -n "$VSTS_WORK" ]; then
   export VSTS_WORK="$(eval echo $VSTS_WORK)"
   mkdir -p "$VSTS_WORK"
+  if [ ! -d "$VSTS_WORK" ]; then
+    echo 1>&2 error: Failed to create specified VSTS_WORK directory: $VSTS_WORK
+    exit 1
+  fi
 fi
 
 touch /vsts/.configure


### PR DESCRIPTION
When invalid VSTS_WORK variables are specified, return non-zero exit code and alert.