### PR TITLE
Added installation of jdk 9, 10, and 11 on both images by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ These derived images include a set of standard capabilities that enable many of 
 - Go 1.9.4 and 1.10
 - Helm 2.9.1
 - HipHop VM (HHVM) 3.27.0
-- Java OpenJDK 7 (1.7.0_95), 8 (1.8.0_162) and 9 (internal)
+- Java OpenJDK 7 (1.7.0_95), 8 (1.8.0_162), 9 (1.9.0_4), 10 (1.10.0_2), and 11 (1.11.24)
 - Java tools (Ant 1.9.6, Gradle 4.6, Maven 3.3.9)
 - kubectl 1.10.4
 - Miniconda 4.5.4

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -91,12 +91,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-8-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
- && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-8-jdk \
+ && apt-get install -y --no-install-recommends openjdk-9-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-10-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-11-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
+    JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
+    JAVA_HOME_10_X64=/usr/lib/jvm/java-10-openjdk-amd64 \
+    JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk-amd64 \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -91,12 +91,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-8-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
- && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-9-jdk \
+ && apt-get install -y --no-install-recommends openjdk-9-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-10-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-11-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
+    JAVA_HOME_10_X64=/usr/lib/jvm/java-10-openjdk-amd64 \
+    JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk-amd64 \
     JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 \
     JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -91,12 +91,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-8-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
- && apt-get -o Dpkg::Options::="--force-overwrite" install -y --no-install-recommends openjdk-$(ADDITIONAL_JDK_VERSION)-jdk \
+ && apt-get install -y --no-install-recommends openjdk-9-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-10-jdk \
+ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-11-jdk \
  && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --set java /usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64/jre/bin/java
 ENV JAVA_HOME_7_X64=/usr/lib/jvm/java-7-openjdk-amd64 \
     JAVA_HOME_8_X64=/usr/lib/jvm/java-8-openjdk-amd64 \
-    JAVA_HOME_$(ADDITIONAL_JDK_VERSION)_X64=/usr/lib/jvm/java-$(ADDITIONAL_JDK_VERSION)-openjdk-amd64 \
+    JAVA_HOME_9_X64=/usr/lib/jvm/java-9-openjdk-amd64 \
+    JAVA_HOME_10_X64=/usr/lib/jvm/java-10-openjdk-amd64 \
+    JAVA_HOME_11_X64=/usr/lib/jvm/java-11-openjdk-amd64 \
     JAVA_HOME=/usr/lib/jvm/java-$(DEFAULT_JDK_VERSION)-openjdk-amd64 \
     JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
 

--- a/ubuntu/standard/versions
+++ b/ubuntu/standard/versions
@@ -1,2 +1,2 @@
 14.04 trusty 8
-16.04 xenial 8 9
+16.04 xenial 8

--- a/update.sh
+++ b/update.sh
@@ -25,7 +25,7 @@ ubuntu() {
     BASE_TAG=ubuntu-$UBUNTU_VERSION
 
     # Update standard image
-    while read TARGET_UBUNTU_VERSION UBUNTU_RELEASE DEFAULT_JDK_VERSION ADDITIONAL_JDK_VERSION; do
+    while read TARGET_UBUNTU_VERSION UBUNTU_RELEASE DEFAULT_JDK_VERSION; do
       if [ "$TARGET_UBUNTU_VERSION" == "$UBUNTU_VERSION" ]; then
         TARGET_DIR=$BASE_DIR/standard
         mkdir -p $TARGET_DIR
@@ -34,7 +34,6 @@ ubuntu() {
           -e s/'$(UBUNTU_VERSION)'/$UBUNTU_VERSION/g \
           -e s/'$(UBUNTU_RELEASE)'/$UBUNTU_RELEASE/g \
           -e s/'$(DEFAULT_JDK_VERSION)'/$DEFAULT_JDK_VERSION/g \
-          -e s/'$(ADDITIONAL_JDK_VERSION)'/${ADDITIONAL_JDK_VERSION:-$DEFAULT_JDK_VERSION}/g \
           standard/Dockerfile.template > $TARGET_DIR/Dockerfile
         if [ -n "$(which unix2dos)" ]; then
           unix2dos -q $TARGET_DIR/Dockerfile


### PR DESCRIPTION
Added installation of jdk 9, 10, and 11 on both images by default as they are now available on the package archive. Also removed the code that had been added to allow for different version of java on each image while Java 9 was unavailable for Ubuntu 14.04.