### PR TITLE
Add MS SQL server client tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ These derived images include a set of standard capabilities that enable many of 
 - kubectl 1.10.4
 - Miniconda 4.5.4
 - MS SQL Server client tools 17.2.0000.1
-- MySQL Client 14.14 
+- MySQL Client 14.14
 - .NET Core SDK 2.1.300 (runtime 2.1.0)
 - Node.js 8.11.3 LTS
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ These derived images include a set of standard capabilities that enable many of 
 - Java tools (Ant 1.9.6, Gradle 4.6, Maven 3.3.9)
 - kubectl 1.10.4
 - Miniconda 4.5.4
-- MySQL Client 14.14
+- MS SQL Server client tools 17.2.0000.1
+- MySQL Client 14.14 
 - .NET Core SDK 2.1.300 (runtime 2.1.0)
 - Node.js 8.11.3 LTS
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -26,6 +26,9 @@ ENV LC_ALL $LANG
 RUN locale-gen $LANG \
  && update-locale
 
+# Accept EULA - needed for certain Microsoft packages
+ENV ACCEPT_EULA=Y
+
 # Install essential build tools
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -153,12 +156,12 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
  && apt-get install -y --no-install-recommends apt-transport-https mono-complete \
  && rm -rf /var/lib/apt/lists/*
 
-# Install MS SQL client (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
+# Install MS SQL Server client tools (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
   && apt-get update \
   && apt-get install -y mssql-tools unixodbc-dev
-ENV PATH $PATH:/opt/mssql-tools/bin
+ENV PATH=$PATH:/opt/mssql-tools/bin
 
 # Install MySQL Client
 RUN apt-get update \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -153,6 +153,13 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
  && apt-get install -y --no-install-recommends apt-transport-https mono-complete \
  && rm -rf /var/lib/apt/lists/*
 
+# Install MS SQL client (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+  && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+  && apt-get update \
+  && apt-get install -y mssql-tools unixodbc-dev
+ENV PATH $PATH:/opt/mssql-tools/bin
+
 # Install MySQL Client
 RUN apt-get update \
   && apt-get install mysql-client -y \


### PR DESCRIPTION
- Installs the MS SQL server client tools (sqlcmd, bcp) into Ubuntu 16.04 image (14.04 is not currently supported).