### PR TITLE
Several tools added to the Linux image for parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,35 +139,36 @@ These derived images include a set of standard capabilities that enable many of 
 - Erlang/OTP 21
 - GCC 5.4.0
 - Go 1.9.4 and 1.10
-- Haskell 
+- Haskell 2014.2.0.0
 - Helm 2.9.1
 - Heroku CLI 7.7.10
-- HipHop VM (HHVM) 3.27.0
+- HipHop VM (HHVM) 3.27.1
 - ImageMagick 6.8.9-9
-- Java OpenJDK 7 (1.7.0_95), 8 (1.8.0_162), 9 (1.9.0_4), 10 (1.10.0_2), and 11 (1.11.24)
+- Java OpenJDK 7 (1.7.0_95), 8 (1.8.0_181), 9 (1.9.0_4), 10 (1.10.0_2), and 11 (1.11.24)
 - Java tools (Ant 1.9.6, Gradle 4.6, Maven 3.3.9)
 - jq 1.5-1
-- kubectl 1.10.4
+- kubectl 1.11.1
 - Mercurial 3.7.3
 - Miniconda 4.5.4
-- MS SQL Server Client Tools 17.2.0000.1
-- MySQL Client 14.14
-- MySQL Server 5.7
-- .NET Core SDK 2.1.300 (runtime 2.1.0)
-- Node.js 8.11.3 LTS
+- Mono 5.14.0.177
+- Microsoft SQL Server Client Tools 17.2.0.1
+- MySQL Client 5.7.23
+- MySQL Server 5.7.23
+- .NET Core SDK 2.1.400 (runtime 2.1.2)
+- Node.js 8.11.3 LTS (with bower, grunt, gulp, n, parcel, and webpack)
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)
 - Pollinate 4.33
 - Powershell Core v6.1.0-preview.2
 - Python 2.7.15, 3.4.8, 3.5.5, 3.6.5 and 3.7.0 (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
 - rebar 3.6.1
 - rsync 3.1.1
-- Ruby 2.3.7, 2.4.4 and 2.5.1 (available through the  [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
+- Ruby 2.3.7, 2.4.4 and 2.5.1 (available through the [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
 - Scala sbt-extras
 - ShellCheck 0.3.7-5
 - Sphinx 2.2.9
 - Subversion 1.9.3
 - xsltproc 1.1.28 and xalan 1.11
-- yarn 1.7.0
+- yarn 1.9.2
 
 ### `docker` images
 These derived images include a version of the Docker CLI and a compatible version of the Docker Compose CLI. This image cannot run most of the built-in VSTS build or release tasks but it can run tasks that invoke arbitrary Docker workloads.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,10 @@ These derived images include a set of standard capabilities that enable many of 
 - CLang 6.0
 - CMake 3.10.2
 - Erlang/OTP 21
+- Firefox 61.0.1
 - GCC 5.4.0
 - Go 1.9.4 and 1.10
+- Google Chrome 68.0
 - Haskell 2014.2.0.0
 - Helm 2.9.1
 - Heroku CLI 7.7.10
@@ -156,9 +158,11 @@ These derived images include a set of standard capabilities that enable many of 
 - MySQL Server 5.7.23
 - .NET Core SDK 2.1.400 (runtime 2.1.2)
 - Node.js 8.11.3 LTS (with bower, grunt, gulp, n, parcel, and webpack)
+- PhantomJS 2.1.1
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)
 - Pollinate 4.33
 - Powershell Core v6.1.0-preview.2
+- PyPy2 (6.0.0) and PyPy3 (6.0.0)
 - Python 2.7.15, 3.4.8, 3.5.5, 3.6.5 and 3.7.0 (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
 - rebar 3.6.1
 - rsync 3.1.1
@@ -167,7 +171,9 @@ These derived images include a set of standard capabilities that enable many of 
 - ShellCheck 0.3.7-5
 - Sphinx 2.2.9
 - Subversion 1.9.3
+- Terraform 0.11.8
 - xsltproc 1.1.28 and xalan 1.11
+- Xvfb 2:1.18.4
 - yarn 1.9.2
 
 ### `docker` images

--- a/README.md
+++ b/README.md
@@ -136,23 +136,35 @@ These derived images include a set of standard capabilities that enable many of 
 - Azure CLI 2.0.38
 - CLang 6.0
 - CMake 3.10.2
+- Erlang/OTP 21
 - GCC 5.4.0
 - Go 1.9.4 and 1.10
+- Haskell 
 - Helm 2.9.1
+- Heroku CLI 7.7.10
 - HipHop VM (HHVM) 3.27.0
+- ImageMagick 6.8.9-9
 - Java OpenJDK 7 (1.7.0_95), 8 (1.8.0_162), 9 (1.9.0_4), 10 (1.10.0_2), and 11 (1.11.24)
 - Java tools (Ant 1.9.6, Gradle 4.6, Maven 3.3.9)
+- jq 1.5-1
 - kubectl 1.10.4
+- Mercurial 3.7.3
 - Miniconda 4.5.4
-- MS SQL Server client tools 17.2.0000.1
+- MS SQL Server Client Tools 17.2.0000.1
 - MySQL Client 14.14
+- MySQL Server 5.7
 - .NET Core SDK 2.1.300 (runtime 2.1.0)
 - Node.js 8.11.3 LTS
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)
+- Pollinate 4.33
 - Powershell Core v6.1.0-preview.2
 - Python 2.7.15, 3.4.8, 3.5.5, 3.6.5 and 3.7.0 (available through the [Use Python Version](https://go.microsoft.com/fwlink/?linkid=871498) task)
+- rebar 3.6.1
+- rsync 3.1.1
 - Ruby 2.3.7, 2.4.4 and 2.5.1 (available through the  [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
 - Scala sbt-extras
+- ShellCheck 0.3.7-5
+- Sphinx 2.2.9
 - Subversion 1.9.3
 - xsltproc 1.1.28 and xalan 1.11
 - yarn 1.7.0

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -245,8 +245,8 @@ ENV bower=/usr/local/bin/bower \
 # Install PhantomJS
 RUN apt-get update \
  && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
- && rm -rf /var/lib/apt/lists/*
- && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && rm -rf /var/lib/apt/lists/* \
+ && export PHANTOM_JS=phantomjs-2.1.1-linux-x86_64 \
  && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
  && tar xvjf $PHANTOM_JS.tar.bz2 \
  && mv $PHANTOM_JS /usr/local/share \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -76,7 +76,7 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
 
 # Install Firefox
 RUN apt-get update \
- && apt-get install -y firefox
+ && apt-get install -y firefox \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Go

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -71,6 +71,11 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
  && apt-get install -y --no-install-recommends esl-erlang \
  && rm -rf /var/lib/apt/lists/*
 
+# Install Firefox
+RUN apt-get update \
+ && apt-get install -y firefox
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -233,6 +238,16 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
+
+# Install PhantomJS
+RUN apt-get update \
+ && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+ && rm -rf /var/lib/apt/lists/*
+ && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
+ && tar xvjf $PHANTOM_JS.tar.bz2 \
+ && mv $PHANTOM_JS /usr/local/share \
+ && ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
 
 # Install PHP versions and libraries
 RUN apt-add-repository ppa:ondrej/php -y \
@@ -431,6 +446,20 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     powershell \
  && rm -rf /var/lib/apt/lists/*
 
+# Instally PyPy2
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy2-v6.0.0-linux64 /opt/pypy2 \
+ && ln -s /opt/pypy2/bin/pypy /usr/local/bin/pypy
+
+# Install PyPy3
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy3-v6.0.0-linux64 /opt/pypy3 \
+ && ln -s /opt/pypy3/bin/pypy3 /usr/local/bin/pypy3
+
 # Install Python
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -465,6 +494,12 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
 
+# Install Terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
 # XSLT transformation
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -477,6 +512,11 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends yarn \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Xvfb
+RUN apt-get update \
+ && apt-get install -y xvfb
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -33,6 +33,9 @@ ENV LC_ALL $LANG
 RUN locale-gen $LANG \
  && update-locale
 
+# Accept EULA - needed for certain Microsoft packages like SQL Server Client Tools
+ENV ACCEPT_EULA=Y
+
 # Install essential build tools
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
     iputils-ping \
     locales \
     openssh-client \
+    rsync\
+    shellcheck \
     sudo \
     telnet \
     time \
@@ -57,6 +59,13 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm cmake.sh
 
+# Install Erlang
+RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc/apt/sources.list.d/eslerlang.list \
+ && wget -O - http://binaries.erlang-solutions.com/debian/erlang_solutions.asc | sudo apt-key add - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends esl-erlang \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -79,8 +88,16 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
  && rm -rf /var/lib/apt/lists/*
 ENV CHROME_BIN /usr/bin/google-chrome
 
+# Install Haskell
+RUN apt-get update \
+ && apt-get install -y haskell-platform \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Helm
 RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+
+# Install Heroku CLI
+RUN curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
 
 # Install HHVM
 RUN apt-get update \
@@ -88,6 +105,15 @@ RUN apt-get update \
  && add-apt-repository https://dl.hhvm.com/ubuntu \
  && apt-get update \
  && apt-get install -y hhvm \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ImageMagick
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --fix-missing \
+    imagemagick \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmagic-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Java OpenJDKs
@@ -139,6 +165,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
  && chmod +x ./kubectl \
  && mv ./kubectl /usr/local/bin/kubectl
 
+# Install Mercurial
+RUN apt-get update \
+  && apt-get install mercurial -y \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Miniconda
 RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
  && chmod +x miniconda.sh \
@@ -158,6 +189,14 @@ RUN apt-get update \
   && apt-get install mysql-client -y \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
+
+# Install MySQL Server
+ENV MYSQL_ROOT_PASSWORD=
+RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
+  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
+  && apt-get update \
+  && apt-get install mysql-server -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/config/ubuntu/14.04/packages-microsoft-prod.deb > packages-microsoft-prod.deb \
@@ -368,6 +407,11 @@ RUN wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar \
  && chmod +x phpunit \
  && mv phpunit /usr/local/bin/phpunit
 
+# Install Pollinate
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pollinate \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
  && curl https://packages.microsoft.com/config/ubuntu/14.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
@@ -385,6 +429,11 @@ RUN apt-get update \
     python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
+# Install rebar3 (for Erlang)
+RUN wget -q -O rebar3 https://s3.amazonaws.com/rebar3/rebar3 \
+ && chmod +x rebar3 \
+ && mv rebar3 /usr/local/bin/rebar3
+
 # Install Ruby requirements
 RUN apt-get update \
  && apt-get install -y libz-dev openssl libssl-dev
@@ -392,6 +441,11 @@ RUN apt-get update \
 # Install Scala build tools
 RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr/local/bin/sbt \
  && chmod 0755 /usr/local/bin/sbt
+
+# Install Sphinx
+RUN apt-get update \
+  && apt-get install sphinxsearch -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion
 RUN apt-get update \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -519,7 +519,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
 
 # Install Xvfb
 RUN apt-get update \
- && apt-get install -y xvfb
+ && apt-get install -y xvfb \
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -1,5 +1,10 @@
 FROM microsoft/vsts-agent:ubuntu-14.04
 
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -167,7 +172,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # Install Mercurial
 RUN apt-get update \
-  && apt-get install mercurial -y \
+  && apt-get install -y mercurial \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Miniconda
@@ -186,16 +191,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
 
 # Install MySQL Client
 RUN apt-get update \
-  && apt-get install mysql-client -y \
+  && apt-get install -y mysql-client \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
 
 # Install MySQL Server
 ENV MYSQL_ROOT_PASSWORD=
-RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
-  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
-  && apt-get update \
-  && apt-get install mysql-server -y \
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD"'
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"'
+RUN apt-get update \
+  && apt-get install -y mysql-server \
   && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
@@ -215,10 +220,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends azcopy \
  && rm -rf /var/lib/apt/lists/*
 
-# Install LTS Node.js and related build tools
+# Install LTS Node.js and related tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n lts \
- && npm install -g bower grunt gulp n \
+ && npm install -g bower \
+ && npm install -g grunt \
+ && npm install -g gulp \
+ && npm install -g n \
+ && npm install -g webpack webpack-cli --save-dev \
+ && npm install -g parcel-bundler
+ && npm i -g npm
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
@@ -444,7 +455,7 @@ RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr
 
 # Install Sphinx
 RUN apt-get update \
-  && apt-get install sphinxsearch -y \
+  && apt-get install -y sphinxsearch \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -228,8 +228,8 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && npm install -g gulp \
  && npm install -g n \
  && npm install -g webpack webpack-cli --save-dev \
- && npm install -g parcel-bundler
- && npm i -g npm
+ && npm install -g parcel-bundler \
+ && npm i -g npm \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -76,7 +76,7 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
 
 # Install Firefox
 RUN apt-get update \
- && apt-get install -y firefox
+ && apt-get install -y firefox \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Go

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -74,6 +74,11 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
  && apt-get install -y --no-install-recommends esl-erlang \
  && rm -rf /var/lib/apt/lists/*
 
+# Install Firefox
+RUN apt-get update \
+ && apt-get install -y firefox
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -244,6 +249,16 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
+
+# Install PhantomJS
+RUN apt-get update \
+ && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+ && rm -rf /var/lib/apt/lists/*
+ && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
+ && tar xvjf $PHANTOM_JS.tar.bz2 \
+ && mv $PHANTOM_JS /usr/local/share \
+ && ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
 
 # Install PHP versions and libraries
 RUN apt-add-repository ppa:ondrej/php -y \
@@ -442,6 +457,20 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     powershell \
  && rm -rf /var/lib/apt/lists/*
 
+# Instally PyPy2
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy2-v6.0.0-linux64 /opt/pypy2 \
+ && ln -s /opt/pypy2/bin/pypy /usr/local/bin/pypy
+
+# Install PyPy3
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy3-v6.0.0-linux64 /opt/pypy3 \
+ && ln -s /opt/pypy3/bin/pypy3 /usr/local/bin/pypy3
+
 # Install Python
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -476,6 +505,12 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
 
+# Install Terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
 # XSLT transformation
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -488,6 +523,11 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends yarn \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Xvfb
+RUN apt-get update \
+ && apt-get install -y xvfb
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update \
     iputils-ping \
     locales \
     openssh-client \
+    rsync\
+    shellcheck \
     sudo \
     telnet \
     time \
@@ -60,6 +62,13 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm cmake.sh
 
+# Install Erlang
+RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc/apt/sources.list.d/eslerlang.list \
+ && wget -O - http://binaries.erlang-solutions.com/debian/erlang_solutions.asc | sudo apt-key add - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends esl-erlang \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -82,8 +91,16 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
  && rm -rf /var/lib/apt/lists/*
 ENV CHROME_BIN /usr/bin/google-chrome
 
+# Install Haskell
+RUN apt-get update \
+ && apt-get install -y haskell-platform \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Helm
 RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+
+# Install Heroku CLI
+RUN curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
 
 # Install HHVM
 RUN apt-get update \
@@ -91,6 +108,15 @@ RUN apt-get update \
  && add-apt-repository https://dl.hhvm.com/ubuntu \
  && apt-get update \
  && apt-get install -y hhvm \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ImageMagick
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --fix-missing \
+    imagemagick \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmagic-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Java OpenJDKs
@@ -142,6 +168,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
  && chmod +x ./kubectl \
  && mv ./kubectl /usr/local/bin/kubectl
 
+# Install Mercurial
+RUN apt-get update \
+  && apt-get install mercurial -y \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Miniconda
 RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
  && chmod +x miniconda.sh \
@@ -161,6 +192,7 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
   && apt-get update \
   && apt-get install -y mssql-tools unixodbc-dev
+  && rm -rf /var/lib/apt/lists/*
 ENV PATH=$PATH:/opt/mssql-tools/bin
 
 # Install MySQL Client
@@ -168,6 +200,14 @@ RUN apt-get update \
   && apt-get install mysql-client -y \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
+
+# Install MySQL Server
+ENV MYSQL_ROOT_PASSWORD=
+RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
+  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
+  && apt-get update \
+  && apt-get install mysql-server -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb > packages-microsoft-prod.deb \
@@ -378,6 +418,11 @@ RUN wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar \
  && chmod +x phpunit \
  && mv phpunit /usr/local/bin/phpunit
 
+# Install Pollinate
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pollinate \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
  && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
@@ -395,6 +440,11 @@ RUN apt-get update \
     python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
+# Install rebar3 (for Erlang)
+RUN wget -q -O rebar3 https://s3.amazonaws.com/rebar3/rebar3 \
+ && chmod +x rebar3 \
+ && mv rebar3 /usr/local/bin/rebar3
+
 # Install Ruby requirements
 RUN apt-get update \
  && apt-get install -y libz-dev openssl libssl-dev
@@ -402,6 +452,11 @@ RUN apt-get update \
 # Install Scala build tools
 RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr/local/bin/sbt \
  && chmod 0755 /usr/local/bin/sbt
+
+# Install Sphinx
+RUN apt-get update \
+  && apt-get install sphinxsearch -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion
 RUN apt-get update \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -527,7 +527,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
 
 # Install Xvfb
 RUN apt-get update \
- && apt-get install -y xvfb
+ && apt-get install -y xvfb \
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -239,8 +239,8 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && npm install -g gulp \
  && npm install -g n \
  && npm install -g webpack webpack-cli --save-dev \
- && npm install -g parcel-bundler
- && npm i -g npm
+ && npm install -g parcel-bundler \
+ && npm i -g npm \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -1,5 +1,10 @@
 FROM microsoft/vsts-agent:ubuntu-16.04
 
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -170,7 +175,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # Install Mercurial
 RUN apt-get update \
-  && apt-get install mercurial -y \
+  && apt-get install -y mercurial \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Miniconda
@@ -191,22 +196,22 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
   && apt-get update \
-  && apt-get install -y mssql-tools unixodbc-dev
+  && apt-get install -y mssql-tools unixodbc-dev \
   && rm -rf /var/lib/apt/lists/*
 ENV PATH=$PATH:/opt/mssql-tools/bin
 
 # Install MySQL Client
 RUN apt-get update \
-  && apt-get install mysql-client -y \
+  && apt-get install -y mysql-client \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
 
 # Install MySQL Server
 ENV MYSQL_ROOT_PASSWORD=
-RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
-  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
-  && apt-get update \
-  && apt-get install mysql-server -y \
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD"'
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"'
+RUN apt-get update \
+  && apt-get install -y mysql-server \
   && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
@@ -226,10 +231,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends azcopy \
  && rm -rf /var/lib/apt/lists/*
 
-# Install LTS Node.js and related build tools
+# Install LTS Node.js and related tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n lts \
- && npm install -g bower grunt gulp n \
+ && npm install -g bower \
+ && npm install -g grunt \
+ && npm install -g gulp \
+ && npm install -g n \
+ && npm install -g webpack webpack-cli --save-dev \
+ && npm install -g parcel-bundler
+ && npm i -g npm
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
@@ -455,7 +466,7 @@ RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr
 
 # Install Sphinx
 RUN apt-get update \
-  && apt-get install sphinxsearch -y \
+  && apt-get install -y sphinxsearch \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -33,7 +33,7 @@ ENV LC_ALL $LANG
 RUN locale-gen $LANG \
  && update-locale
 
-# Accept EULA - needed for certain Microsoft packages
+# Accept EULA - needed for certain Microsoft packages like SQL Server Client Tools
 ENV ACCEPT_EULA=Y
 
 # Install essential build tools

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -253,8 +253,8 @@ ENV bower=/usr/local/bin/bower \
 # Install PhantomJS
 RUN apt-get update \
  && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
- && rm -rf /var/lib/apt/lists/*
- && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && rm -rf /var/lib/apt/lists/* \
+ && export PHANTOM_JS=phantomjs-2.1.1-linux-x86_64 \
  && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
  && tar xvjf $PHANTOM_JS.tar.bz2 \
  && mv $PHANTOM_JS /usr/local/share \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -245,8 +245,8 @@ ENV bower=/usr/local/bin/bower \
 # Install PhantomJS
 RUN apt-get update \
  && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
- && rm -rf /var/lib/apt/lists/*
- && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && rm -rf /var/lib/apt/lists/* \
+ && export PHANTOM_JS=phantomjs-2.1.1-linux-x86_64 \
  && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
  && tar xvjf $PHANTOM_JS.tar.bz2 \
  && mv $PHANTOM_JS /usr/local/share \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -76,7 +76,7 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
 
 # Install Firefox
 RUN apt-get update \
- && apt-get install -y firefox
+ && apt-get install -y firefox \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Go

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -71,6 +71,11 @@ RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc
  && apt-get install -y --no-install-recommends esl-erlang \
  && rm -rf /var/lib/apt/lists/*
 
+# Install Firefox
+RUN apt-get update \
+ && apt-get install -y firefox
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -233,6 +238,16 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
+
+# Install PhantomJS
+RUN apt-get update \
+ && apt-get install -y chrpath libssl-dev libxft-dev libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+ && rm -rf /var/lib/apt/lists/*
+ && export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64" \
+ && wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2 \
+ && tar xvjf $PHANTOM_JS.tar.bz2 \
+ && mv $PHANTOM_JS /usr/local/share \
+ && ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
 
 # Install PHP versions and libraries
 RUN apt-add-repository ppa:ondrej/php -y \
@@ -431,6 +446,20 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     powershell \
  && rm -rf /var/lib/apt/lists/*
 
+# Instally PyPy2
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy2-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy2-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy2-v6.0.0-linux64 /opt/pypy2 \
+ && ln -s /opt/pypy2/bin/pypy /usr/local/bin/pypy
+
+# Install PyPy3
+RUN wget -q -P /tmp https://bitbucket.org/pypy/pypy/downloads/pypy3-v6.0.0-linux64.tar.bz2 \
+ && tar -x -C /opt -f /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && rm /tmp/pypy3-v6.0.0-linux64.tar.bz2 \
+ && mv /opt/pypy3-v6.0.0-linux64 /opt/pypy3 \
+ && ln -s /opt/pypy3/bin/pypy3 /usr/local/bin/pypy3
+
 # Install Python
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -465,6 +494,12 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
 
+# Install Terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
 # XSLT transformation
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -477,6 +512,11 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends yarn \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Xvfb
+RUN apt-get update \
+ && apt-get install -y xvfb
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -33,6 +33,9 @@ ENV LC_ALL $LANG
 RUN locale-gen $LANG \
  && update-locale
 
+# Accept EULA - needed for certain Microsoft packages like SQL Server Client Tools
+ENV ACCEPT_EULA=Y
+
 # Install essential build tools
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -519,7 +519,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
 
 # Install Xvfb
 RUN apt-get update \
- && apt-get install -y xvfb
+ && apt-get install -y xvfb \
  && rm -rf /var/lib/apt/lists/*
 
 # Download hosted tool cache

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -11,6 +11,8 @@ RUN apt-get update \
     iputils-ping \
     locales \
     openssh-client \
+    rsync\
+    shellcheck \
     sudo \
     telnet \
     time \
@@ -57,6 +59,13 @@ RUN curl -sL https://cmake.org/files/v3.10/cmake-3.10.2-Linux-x86_64.sh -o cmake
  && ./cmake.sh --prefix=/usr/local --exclude-subdir \
  && rm cmake.sh
 
+# Install Erlang
+RUN echo "deb http://binaries.erlang-solutions.com/debian xenial contrib" > /etc/apt/sources.list.d/eslerlang.list \
+ && wget -O - http://binaries.erlang-solutions.com/debian/erlang_solutions.asc | sudo apt-key add - \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends esl-erlang \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Go
 RUN curl -sL https://dl.google.com/go/go1.9.4.linux-amd64.tar.gz -o go1.9.4.linux-amd64.tar.gz \
  && mkdir -p /usr/local/go1.9.4 \
@@ -79,8 +88,16 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
  && rm -rf /var/lib/apt/lists/*
 ENV CHROME_BIN /usr/bin/google-chrome
 
+# Install Haskell
+RUN apt-get update \
+ && apt-get install -y haskell-platform \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Helm
 RUN curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get | bash
+
+# Install Heroku CLI
+RUN curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
 
 # Install HHVM
 RUN apt-get update \
@@ -88,6 +105,15 @@ RUN apt-get update \
  && add-apt-repository https://dl.hhvm.com/ubuntu \
  && apt-get update \
  && apt-get install -y hhvm \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install ImageMagick
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --fix-missing \
+    imagemagick \
+    libmagickcore-dev \
+    libmagickwand-dev \
+    libmagic-dev \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Java OpenJDKs
@@ -139,6 +165,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
  && chmod +x ./kubectl \
  && mv ./kubectl /usr/local/bin/kubectl
 
+# Install Mercurial
+RUN apt-get update \
+  && apt-get install mercurial -y \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Miniconda
 RUN curl -sL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -o miniconda.sh \
  && chmod +x miniconda.sh \
@@ -158,6 +189,14 @@ RUN apt-get update \
   && apt-get install mysql-client -y \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
+
+# Install MySQL Server
+ENV MYSQL_ROOT_PASSWORD=
+RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
+  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
+  && apt-get update \
+  && apt-get install mysql-server -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
 RUN curl https://packages.microsoft.com/config/ubuntu/$(UBUNTU_VERSION)/packages-microsoft-prod.deb > packages-microsoft-prod.deb \
@@ -368,6 +407,11 @@ RUN wget -q -O phpunit https://phar.phpunit.de/phpunit-7.phar \
  && chmod +x phpunit \
  && mv phpunit /usr/local/bin/phpunit
 
+# Install Pollinate
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pollinate \
+ && rm -rf /var/lib/apt/lists/*
+
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
  && curl https://packages.microsoft.com/config/ubuntu/$(UBUNTU_VERSION)/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
@@ -385,6 +429,11 @@ RUN apt-get update \
     python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
+# Install rebar3 (for Erlang)
+RUN wget -q -O rebar3 https://s3.amazonaws.com/rebar3/rebar3 \
+ && chmod +x rebar3 \
+ && mv rebar3 /usr/local/bin/rebar3
+
 # Install Ruby requirements
 RUN apt-get update \
  && apt-get install -y libz-dev openssl libssl-dev
@@ -392,6 +441,11 @@ RUN apt-get update \
 # Install Scala build tools
 RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr/local/bin/sbt \
  && chmod 0755 /usr/local/bin/sbt
+
+# Install Sphinx
+RUN apt-get update \
+  && apt-get install sphinxsearch -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion
 RUN apt-get update \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -228,8 +228,8 @@ RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && npm install -g gulp \
  && npm install -g n \
  && npm install -g webpack webpack-cli --save-dev \
- && npm install -g parcel-bundler
- && npm i -g npm
+ && npm install -g parcel-bundler \
+ && npm i -g npm \
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -1,5 +1,10 @@
 FROM microsoft/vsts-agent:$(VSTS_AGENT_TAG)
 
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
 # Install basic command-line utilities
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -167,7 +172,7 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s
 
 # Install Mercurial
 RUN apt-get update \
-  && apt-get install mercurial -y \
+  && apt-get install -y mercurial \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Miniconda
@@ -186,16 +191,16 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E03280
 
 # Install MySQL Client
 RUN apt-get update \
-  && apt-get install mysql-client -y \
+  && apt-get install -y mysql-client \
   && rm -rf /var/lib/apt/lists/*
 ENV mysql=/usr/bin/mysql
 
 # Install MySQL Server
 ENV MYSQL_ROOT_PASSWORD=
-RUN debconf-set-selections <<< 'mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD' \
-  && debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD' \
-  && apt-get update \
-  && apt-get install mysql-server -y \
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password password $MYSQL_ROOT_PASSWORD"'
+RUN bash -c 'debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"'
+RUN apt-get update \
+  && apt-get install -y mysql-server \
   && rm -rf /var/lib/apt/lists/*
 
 # Install .NET Core SDK and initialize package cache
@@ -215,10 +220,16 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends azcopy \
  && rm -rf /var/lib/apt/lists/*
 
-# Install LTS Node.js and related build tools
+# Install LTS Node.js and related tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
  && ~/n/bin/n lts \
- && npm install -g bower grunt gulp n \
+ && npm install -g bower \
+ && npm install -g grunt \
+ && npm install -g gulp \
+ && npm install -g n \
+ && npm install -g webpack webpack-cli --save-dev \
+ && npm install -g parcel-bundler
+ && npm i -g npm
  && rm -rf ~/n
 ENV bower=/usr/local/bin/bower \
     grunt=/usr/local/bin/grunt
@@ -444,7 +455,7 @@ RUN curl -s https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt > /usr
 
 # Install Sphinx
 RUN apt-get update \
-  && apt-get install sphinxsearch -y \
+  && apt-get install -y sphinxsearch \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Subversion


### PR DESCRIPTION
Added tools:
- Erlang/OTP
- Haskell
- Heroku CLI
- ImageMagick
- Mercurial
- MySQL Server
- Node.js packages: parcel, webpack
- Pollinate
- rebar3
- rsync
- ShellCheck
- Sphinx

Also:
- To make it easier for builds and releases to run **apt-get**, configure apt to not require confirmation (assume the `-y` argument by default).

CC: @vtbassmatt