### PR TITLE
add jq and terraform tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ These derived images include a set of standard capabilities that enable many of 
 - Ruby 2.3.7, 2.4.4 and 2.5.1 (available through the  [Use Ruby Version](https://go.microsoft.com/fwlink/?linkid=2005989) task)
 - Scala sbt-extras
 - Subversion 1.9.3
+- Terraform 0.11.8
 - xsltproc 1.1.28 and xalan 1.11
 - yarn 1.7.0
 

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
+    jq \
     locales \
     openssh-client \
     sudo \
@@ -399,6 +400,12 @@ RUN apt-get update \
     subversion \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
+
+# Install terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # XSLT transformation
 RUN apt-get update \

--- a/ubuntu/14.04/standard/Dockerfile
+++ b/ubuntu/14.04/standard/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
-    jq \
     locales \
     openssh-client \
     sudo \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
+    jq \
     locales \
     openssh-client \
     sudo \
@@ -409,6 +410,12 @@ RUN apt-get update \
     subversion \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
+
+# Install terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # XSLT transformation
 RUN apt-get update \

--- a/ubuntu/16.04/standard/Dockerfile
+++ b/ubuntu/16.04/standard/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
-    jq \
     locales \
     openssh-client \
     sudo \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -9,6 +9,7 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
+    jq \
     locales \
     openssh-client \
     sudo \
@@ -399,6 +400,12 @@ RUN apt-get update \
     subversion \
  && rm -rf /var/lib/apt/lists/*
 ENV svn=/usr/bin/svn
+
+# Install terraform
+RUN TERRAFORM_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r .current_version) \
+ && curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip \
+ && unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /usr/local/bin \
+ && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 # XSLT transformation
 RUN apt-get update \

--- a/ubuntu/standard/Dockerfile.template
+++ b/ubuntu/standard/Dockerfile.template
@@ -9,7 +9,6 @@ RUN apt-get update \
     ftp \
     iproute2 \
     iputils-ping \
-    jq \
     locales \
     openssh-client \
     sudo \


### PR DESCRIPTION
Hi, 
Ref. #136
This PR is proposal to add `terraform` tool in VSTS Agent Ubuntu Docker Images. It is very popular tool and we currently use it alot in VSTS pipelines for deploying Azure infrastructure. This PR also adds `jq` tool for convenience, since it's also very popular and used to help determine current terraform version in this proposal.
FYI both `kubectl` and `helm` is already included in the image, but also have supported deploy and tool tasks in VSTS. Terraform currently don't have any official VSTS task yet. This is justification for adding the tool to the image. Thanks for your consideration, 