### PR TITLE
Update Node version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ These derived images include a set of standard capabilities that enable many of 
 - MySQL Client 5.7.23
 - MySQL Server 5.7.23
 - .NET Core SDK 2.2.102 (runtime 2.2.1)
-- Node.js 8.11.3 LTS (with bower, grunt, gulp, n, parcel, and webpack)
+- Node.js 10.15.0 LTS (with bower, grunt, gulp, n, parcel, and webpack)
 - PhantomJS 2.1.1
 - PHP 5.6, 7.0, 7.1, and 7.2 (with composer, phpunit, and xdebug)
 - Pollinate 4.33


### PR DESCRIPTION
Updated Node version in readme to reflect version included in image `4e699c33f7f0` (latest version of `ubuntu-16.04-docker-18.06.1-ce-standard` tag)